### PR TITLE
#4 - Encode screenshot src and href attribute

### DIFF
--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -150,7 +150,7 @@ var HTMLReport = function() {
                   screenshotName+=(report.browser + ' ');
               }
               if (report.testSuitePrefix){
-                  screenshotName+=(suite.name + ' ');
+                  screenshotName+=(suite.name.replace(/\./g,' ') + ' ');
               }
               screenshotName+=testCasesNames[j] + '.png';
 
@@ -161,13 +161,13 @@ var HTMLReport = function() {
 
                 if ( !report.browserPrefix && !report.testSuitePrefix && !report.fileNameSeparator ) {
                     //For those still using the legacy/default naming
-                    screenshotsNamesOnFailure.push(report.browser +'-'+ suite.name.substring(suite.name.indexOf(".")+1) + ' ' + testCasesNames[j] + '.png');
+                    screenshotsNamesOnFailure.push(encodeURIComponent(report.browser +'-'+ suite.name.substring(suite.name.indexOf(".")+1) + ' ' + testCasesNames[j] + '.png'));
                 } else {
-                    screenshotsNamesOnFailure.push(screenshotName);
+                    screenshotsNamesOnFailure.push(encodeURIComponent(screenshotName));
                 }
             }
             else {
-              screenshotsNamesOnFailure.push(report.browser +'-'+ suite.name + ' ' + testCasesNames[j] + '.png');
+              screenshotsNamesOnFailure.push(encodeURIComponent(report.browser +'-'+ suite.name.replace(/\./g,' ') + ' ' + testCasesNames[j] + '.png'));
             }
           }
       }


### PR DESCRIPTION
Hi @jamesomorodion , @abhishekkyd 
I noticed the same problem as other people noticed under issue #4 . I looked inside your code and I noticed that inside code the *href* and *src* attribute does not encode spaces. After encoding them, everything started to work for me.

I noticed as well second problem.
The screenshot names aren't the same as names created in the reporter if we use this logic:
describe('testSuite', function() {
  describe('testSuiteDeeperName', function() {
     it('test1', function() {})
        expect(2).toBe(1)
  })
})

The reporter will expect to find:
'''
testSuite.testSuiteDeeperName test1.png
'''
screenshot, but inside screenshot folder we will find:
'''
testSuite testSuiteDeeperName test1.png
'''
Please let me know if it suits you, or I should fix something.