### PR TITLE
#11 Add appVersion option to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,18 @@ How to use
                 outputFilename: 'ProtractorTestReport',
                 screenshotPath: './screenshots',
                 testBrowser: browserName,
-                browserVersion: browserVersion
+                browserVersion: browserVersion,
+                appVersion: '1.23'
             };
     new HTMLReport().from('xmlresults.xml', testConfig);
     ```
+
+    ---
+    
+    #### Info
+    appVersion - additional attribute. If appVersion option is set, this information it will be displayed under *Environment* section. In other way, it will be not mentioned under *Environment* section
+
+    ---
 
 * Using with protractor conf.js file
 

--- a/examples/example1/conf.js
+++ b/examples/example1/conf.js
@@ -3,6 +3,14 @@ var jasmineReporters = require('jasmine-reporters');
 var htmlReporter = require('../lib/protractor-xml2html-reporter');
 var fs = require('fs-extra');
 
+const capitalize = (s) => {
+  if (typeof s !== 'string') {
+    return ''
+  } else {
+    return s.charAt(0).toUpperCase() + s.slice(1)
+  }
+}
+
 exports.config = {
 	
     seleniumAddress: 'http://localhost:4444/wd/hub',
@@ -38,7 +46,7 @@ exports.config = {
 						var browserName = caps.get('browserName');
 
 						browser.takeScreenshot().then(function (png) {
-							var stream = fs.createWriteStream('./reports/screenshots/' + browserName + '-' + result.fullName + '.png');
+							var stream = fs.createWriteStream('./reports/screenshots/' + capitalize(browserName) + '-' + result.fullName + '.png');
 							stream.write(new Buffer(png, 'base64'));
 							stream.end();
 						});
@@ -54,10 +62,21 @@ exports.config = {
 
         capsPromise.then(function (caps) {
             browserName = caps.get('browserName');
-            browserVersion = caps.get('version');
-            platform = caps.get('platform');
+
+            if (typeof caps.get('browserVersion') === 'undefined') {
+                browserVersion = caps.get('Version')
+            } else {
+                browserVersion = caps.get('browserVersion')
+            }
+
+            if (typeof caps.get('platform') === 'undefined') {
+                platform = caps.get('platformName')
+            } else{
+                platform = caps.get('platform')
+            }
 
             testConfig = {
+                appVersion: 'someVersion',
                 reportTitle: 'Protractor Test Execution Report',
                 outputPath: './reports/',
                 outputFilename: 'ProtractorTestReport',

--- a/lib/index.tmpl
+++ b/lib/index.tmpl
@@ -61,6 +61,13 @@
                   </div>
               </div>
             </div>
+            <div class="row" <%=report.appDivVisible%>>
+              <div class="clearfix metadata col-xs-12 col-sm-6 col-md-6 col-lg-6">
+                <div class="pull-left">
+                    <strong> AppVersion: </strong><%= report.appVersion %>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -10,6 +10,8 @@ var suitesData = [];
 
 //stores data that is used for the whole report
 var report = {
+  appVersion: '',
+  appDivVisible: false,
   name: '',
   browser: '',
   browserVersion: '',
@@ -194,10 +196,12 @@ var HTMLReport = function() {
 
 this.from = function(reportXml, testConfig) {
     //set report data based on testConfig
+    report.appVersion = testConfig.appVersion || 'unknown';
+    report.appDivVisible = (report.appVersion === 'unknown') ? 'style="display: none;"' : '';
     report.name = testConfig.reportTitle || 'Protractor Test Execution Report';
     report.screenshotPath = testConfig.screenshotPath || './screenshots';
     report.browser = testConfig.testBrowser || 'unknown';
-    report.browserVersion = testConfig.browserVersion || 'unknownBrowser';
+    report.browserVersion = testConfig.browserVersion || 'unknownBrowserVersion';
     report.modifiedSuiteName = testConfig.modifiedSuiteName || false;
     report.browserPrefix = testConfig.browserPrefix || false;
     report.testSuitePrefix = testConfig.testSuitePrefix || false;
@@ -207,7 +211,7 @@ this.from = function(reportXml, testConfig) {
     } else {
       report.screenshotsOnlyOnFailure = testConfig.screenshotsOnlyOnFailure;
     }
-    report.platform = testConfig.testPlatform || 'unknown';
+    report.platform = testConfig.testPlatform || 'unknownOS';
 
     //generate statistics
     var testDetails = generateSummaries(reportXml, report);


### PR DESCRIPTION
Hi, 

During setup my project, I also noticed lack of appVersion tag under environment section. 
I added small changes which enables adding appVersion.

The logic is to display AppVersion label if the appVersion value is set, in other option to do not display this option under Environment section

![image](https://user-images.githubusercontent.com/22797365/65510282-ddf89680-ded4-11e9-9b4b-c474eca57d0d.png)

Please let me know is it suits to you or should I need to fix something